### PR TITLE
Add multiple master connection detection and handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 dbfailover
 ==========
 
-[![GoDoc](https://godoc.org/bitbucket.org/advbet/dbfailover?status.svg)](https://godoc.org/bitbucket.org/advbet/dbfailover)
+[![GoDoc](https://godoc.org/github.com/advbet/dbfailover?status.svg)](https://godoc.org/github.com/advbet/dbfailover)
 
 This is a go package for managing access to multiple MySQL/MariaDB servers. This
 package takes a list of DB handlers (as slice of `*sql.DB`) and provides methods
@@ -17,6 +17,12 @@ master. This is important to take into consideration when performing server
 failover. If server is actually running in slave mode but have `read_only` flag
 set to false it will receive DML queries from the services using this package
 and this will most likely cause data replication failure.
+
+Multiple master connection handling
+---------------------
+
+If multiple connections with master role are detected, when calling `Master()` method, a special `*sql.DB`
+connections is returned which when used, will always return `ErrMultipleMasters` error.
 
 Usage example
 -------------

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ Multiple master connection handling
 ---------------------
 
 If multiple connections with master role are detected, when calling `Master()` method, a special `*sql.DB`
-connections is returned which when used, will always return `ErrMultipleMasters` error.
+connection is returned which when used, will always return `ErrMultipleMasters` error.
 
 Usage example
 -------------

--- a/dbstatus.go
+++ b/dbstatus.go
@@ -117,11 +117,13 @@ func mergeStatus(ss slaveStatus, rs readOnlyStatus, ws wsrepStatus, maxReplicati
 }
 
 func checkDBStatus(db *sql.DB, cfg Config) dbStatus {
-	var wg sync.WaitGroup
+	var (
+		wg sync.WaitGroup
 
-	var ss slaveStatus
-	var rs readOnlyStatus
-	var ws wsrepStatus
+		ss slaveStatus
+		rs readOnlyStatus
+		ws wsrepStatus
+	)
 
 	wg.Add(1)
 	go func() {
@@ -152,8 +154,10 @@ func checkReadOnlyStatus(db *sql.DB, timeout time.Duration) readOnlyStatus {
 	ctx, cancel := context.WithTimeout(context.Background(), timeout)
 	defer cancel()
 
-	var key string
-	var val string
+	var (
+		key string
+		val string
+	)
 	start := time.Now()
 	err := db.QueryRowContext(ctx, "SHOW VARIABLES LIKE 'read_only'").Scan(&key, &val)
 	d := time.Since(start)
@@ -175,8 +179,10 @@ func checkWsrepStatus(db *sql.DB, timeout time.Duration) wsrepStatus {
 	ctx, cancel := context.WithTimeout(context.Background(), timeout)
 	defer cancel()
 
-	var key string
-	var val string
+	var (
+		key string
+		val string
+	)
 	start := time.Now()
 	err := db.QueryRowContext(ctx, "SHOW VARIABLES LIKE 'wsrep_on'").Scan(&key, &val)
 	d := time.Since(start)

--- a/error_driver.go
+++ b/error_driver.go
@@ -1,0 +1,28 @@
+package dbfailover
+
+import (
+	"database/sql"
+	"database/sql/driver"
+	"errors"
+)
+
+func init() {
+	sql.Register("dbfailover_err_driver", errorDriver{})
+}
+
+// newMultipleMasterErrConn returns a *sql.DB connection which upon usage will
+// always return a ErrMultipleMasters error.
+func newMultipleMasterErrConn() *sql.DB {
+	db, _ := sql.Open("dbfailover_err_driver", ErrMultipleMasters.Error())
+	return db
+}
+
+type errorDriver struct{}
+
+func (errorDriver) Open(err string) (driver.Conn, error) {
+	if err == ErrMultipleMasters.Error() {
+		return nil, ErrMultipleMasters
+	}
+
+	return nil, errors.New(err)
+}

--- a/error_driver_test.go
+++ b/error_driver_test.go
@@ -1,0 +1,18 @@
+package dbfailover
+
+import (
+	"errors"
+	"testing"
+)
+
+func TestNewFaultyTopologyErrDriver(t *testing.T) {
+	db := newMultipleMasterErrConn()
+	if db == nil {
+		t.Fatal("connection is nil")
+	}
+
+	_, err := db.Exec("SELECT 1")
+	if !errors.Is(err, ErrMultipleMasters) {
+		t.Errorf("expected %v, got %v", ErrMultipleMasters, err)
+	}
+}

--- a/error_driver_test.go
+++ b/error_driver_test.go
@@ -5,7 +5,7 @@ import (
 	"testing"
 )
 
-func TestNewFaultyTopologyErrDriver(t *testing.T) {
+func TestNewMultipleMasterErrConn(t *testing.T) {
 	db := newMultipleMasterErrConn()
 	if db == nil {
 		t.Fatal("connection is nil")

--- a/selection.go
+++ b/selection.go
@@ -13,11 +13,13 @@ type selection struct {
 }
 
 func makeSelection(statuses map[*sql.DB]dbStatus, lastMaster *sql.DB) selection {
-	var master *sql.DB
-	var masterLatency time.Duration
-	var slave *sql.DB
-	var slaveLatency time.Duration
-	var multipleMasters bool
+	var (
+		master          *sql.DB
+		masterLatency   time.Duration
+		slave           *sql.DB
+		slaveLatency    time.Duration
+		multipleMasters bool
+	)
 
 	for db, status := range statuses {
 		switch status.role {

--- a/selection_test.go
+++ b/selection_test.go
@@ -67,16 +67,17 @@ func TestMakeSelection(t *testing.T) {
 			},
 		},
 		{
-			msg: "two masters one slave pick lowest latency",
+			msg: "two masters one slave pick lowest latency and set multiple master flag",
 			states: map[*sql.DB]dbStatus{
 				db1: {role: roleMaster, latency: 5 * time.Second},
 				db2: {role: roleMaster, latency: 2 * time.Second},
 				db3: {role: roleSlave, latency: 1 * time.Second},
 			},
 			want: selection{
-				master:     db2,
-				slave:      db3,
-				lastMaster: db2,
+				master:          db2,
+				slave:           db3,
+				lastMaster:      db2,
+				multipleMasters: true,
 			},
 		},
 		{


### PR DESCRIPTION
This adds detection when multiple master roles are found.

When multiple masters are found, calling Master() method returns a special connection which on usage will always return an error.

This change, hopefully, in case of master-slave misconfiguration, will minimize or prevent data corruption.